### PR TITLE
Fixed a building error

### DIFF
--- a/Universal Walking Simulator/UE/other.h
+++ b/Universal Walking Simulator/UE/other.h
@@ -1271,7 +1271,7 @@ struct FGuid
 	unsigned int C;
 	unsigned int D;
 
-	bool operator==(const FGuid& other)
+	bool operator==(const FGuid other)
 	{
 		return A == other.A && B == other.B && C == other.C && D == other.D;
 	}


### PR DESCRIPTION
When building you would encounter the following error

Gravité    Code    Description    Projet    Fichier    Ligne    État de la suppression    Détails
Erreur    C2666    'FGuid::operator ==' : les fonctions surchargées ont des conversions similaires.    Universal Walking Simulator    C:\Users\Niwis\source\repos\Universal-Walking-Simulator\Universal Walking Simulator\gui.h    1276

It makes no sense to take a reference for a const operator that doesnt even change the values